### PR TITLE
Basis opstelling voor Detail Pagina

### DIFF
--- a/server.js
+++ b/server.js
@@ -44,6 +44,21 @@ app.get('/artwork', async function (request, response) {
       }
     });
 
+    app.get('/details/:id', async function (request, response) {
+      try {
+          const artId = request.params.id;
+          const specificArt = await fetch(`https://www.rijksmuseum.nl/api/nl/collection?key=${API_KEY}&q=${artId}`);
+          const artData = await specificArt.json();
+          
+      response.render('artwork.liquid', {
+              art: artData.artObjects
+      });
+        } catch (error) {
+          console.error("Something went wrong in the page check error:",error);
+              response.status(500).render("error.liquid");
+        }
+      });
+
 app.set('port', process.env.PORT || 8000)
 
 app.listen(app.get('port'), function () {

--- a/views/artwork.liquid
+++ b/views/artwork.liquid
@@ -11,7 +11,7 @@
             {% if art.webImage %}
                 <img src="{{ art.webImage.url }}" alt="{{ art.title }}" width="300" />
             {% endif %}
-            <p><a href="{{ art.links.web }}" target="_blank">Bekijk op Rijksmuseum.nl</a></p>
+            <p><a href="/details/{{ art.objectNumber }}" target="_blank">Bekijk details</a></p>
             </li>
         {% endfor %}
         </ul> 

--- a/views/details.liquid
+++ b/views/details.liquid
@@ -1,0 +1,22 @@
+{% render 'partials/head.liquid' %}
+
+{% include 'partials/header.liquid' %}
+
+    <section class="artList">
+        <ul>
+        {% for art in art %}
+            <li>
+            <h2>{{ art.title }}</h2>
+            <p><strong>Kunstenaar:</strong> {{ art.principalOrFirstMaker }}</p>
+            {% if art.webImage %}
+                <img src="{{ art.webImage.url }}" alt="{{ art.title }}" width="300" />
+            {% endif %}
+            <p><a href="{{ art.links.web }}" target="_blank">Bekijk op Rijksmuseum.nl</a></p>
+            </li>
+        {% endfor %}
+        </ul> 
+    </section>
+
+{% comment %} {% include 'partials/footer.liquid' %} {% endcomment %}
+
+{% render 'partials/foot.liquid' %}


### PR DESCRIPTION
## What does this change?
 
Issue #3 
 
Basis opstelling gemaakt voor de detail pagina, ik heb de volgende functionele punten verwerkt:
- [x] Get route aanmaken op basis van een specifiek objectNumber ( id ) 
- [x] Simpele structuur voor de view om de data te tonen
- [x] De anchor href aangepast zodat die nu navigeert naar een specifiek pagina o.b.v. objectNumber

[artwork-270projects.onrender.com](https://artwork-270projects.onrender.com/)
 
## How Has This Been Tested?

- [x] User Test
 
## Images
![image](https://github.com/user-attachments/assets/078f1dc6-6eb3-45bd-884c-f186be7780c8)
 
