### PR TITLE
#12 Made the Art List responsive for Desktop and Tablet

### DIFF
--- a/public/styles/main-style.css
+++ b/public/styles/main-style.css
@@ -141,6 +141,9 @@ footer {
     position: relative;
     overflow: hidden;
     display: none;
+    @media (min-width: 768px) {
+        display: block;
+    }
   }
   
   .featured-art img {

--- a/views/partials/art-list.liquid
+++ b/views/partials/art-list.liquid
@@ -16,6 +16,7 @@
 {% endfor %}
 
   <div class="art-list">
+    <h2>Rijksmuseum</h2>
     {% for art in art %}
     <div class="art-item">
       <img src="{{ art.webImage.url }}" alt="{{ art.title }}">


### PR DESCRIPTION
## Wat heb ik aangepast
- Op het moment dat je een device hebt met een width van 768px krijg je een featured art item aan de linkerkant van je scherm

## Afbeeldingen op basis van pixels
### Mobile
![image](https://github.com/user-attachments/assets/65852ec3-a00b-4373-9b0d-6a7fe3082dc4)
### Tablet
![image](https://github.com/user-attachments/assets/9aa75f06-88c7-4d98-94ed-354adde5fc00)
### Desktop
![image](https://github.com/user-attachments/assets/e515022b-d274-4e92-8a4c-ff99c977b63a)
